### PR TITLE
export-ingester: archive exporter

### DIFF
--- a/export-ingester/export_ingester/api_client/__init__.py
+++ b/export-ingester/export_ingester/api_client/__init__.py
@@ -1,4 +1,4 @@
 from .client import APIClient
-from .models import ExportParams
+from .models import ArchiveParams, ExportParams
 
-__all__ = ("APIClient", "ExportParams")
+__all__ = ("APIClient", "ExportParams", "ArchiveParams")

--- a/export-ingester/export_ingester/api_client/client.py
+++ b/export-ingester/export_ingester/api_client/client.py
@@ -117,4 +117,6 @@ class APIClient:
                 headers={"Host": "fastapi.localhost"},
                 params=params,
             )
+            logger.debug("response is ", response.content)
+
             return mapper(response.content)

--- a/export-ingester/export_ingester/api_client/client.py
+++ b/export-ingester/export_ingester/api_client/client.py
@@ -3,6 +3,7 @@ import urllib.parse
 from enum import StrEnum
 from functools import partial
 from typing import AsyncGenerator, Callable, TypeVar
+import logging
 
 import httpx
 
@@ -19,6 +20,8 @@ from .models import (
 
 T = TypeVar("T")
 
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
 
 class Routes(StrEnum):
     EXPORTS = "/api/1/exports"
@@ -45,6 +48,7 @@ class APIClient:
         self,
         params: ArchiveParams,
     ) -> list[ArchiveModel]:
+        logger.info("Fetching archives with parameters: %s", params)
         return [item async for item in self._stream_archives(params)]
 
     async def _stream_exports(
@@ -85,7 +89,7 @@ class APIClient:
         get_response = partial(
             self._get_response, url, paginator_cls.model_validate_json
         )
-
+        logger.debug("Requesting initial data from %s with params: %s", url, default_params)
         initial_data = await get_response({"offset": 0, **default_params})
         for item in initial_data.data:
             yield item
@@ -107,6 +111,7 @@ class APIClient:
         params: dict | None = None,
     ) -> T:
         async with self.sem:
+            logger.debug("Sending request to %s with params: %s", endpoint, params)
             response = await self.client.get(
                 urllib.parse.urljoin(self.base_url, endpoint),
                 headers={"Host": "fastapi.localhost"},

--- a/export-ingester/export_ingester/api_client/models.py
+++ b/export-ingester/export_ingester/api_client/models.py
@@ -8,7 +8,7 @@ DataT = TypeVar("DataT")
 
 
 class Params(BaseModel):
-    limit: int = 250
+    limit: int = 99
 
 
 class PaginatedResponse(BaseModel, Generic[DataT]):

--- a/export-ingester/export_ingester/archive_export.py
+++ b/export-ingester/export_ingester/archive_export.py
@@ -9,10 +9,14 @@ from .ingest import get_managed_export_ingester
 async def main(experiment_id: str):
     settings = Settings()
     remote = f"/scratch-shared/amftrack2024/daily/{experiment_id}.json"
+    sbatch_command = ("sbatch /gpfs/home4/mkerrwinter/orchestrator/orchestrator/bash_scripts/downloader_archive.sh"
+     " /scratch-shared/amftrack2024/test_tape")
     async with get_managed_export_ingester(settings) as export_ingester:
         await export_ingester.ingest_archive(
             remote, ArchiveParams(experiment_id=experiment_id)
         )
+        await export_ingester.run_sbatch_command(sbatch_command, remote)
+
 
 
 if __name__ == "__main__":

--- a/export-ingester/export_ingester/archive_export.py
+++ b/export-ingester/export_ingester/archive_export.py
@@ -1,0 +1,20 @@
+import asyncio
+import sys
+
+from .api_client import ArchiveParams
+from .config import Settings
+from .ingest import get_managed_export_ingester
+
+
+async def main(experiment_id: str):
+    settings = Settings()
+    remote = f"/scratch-shared/amftrack2024/daily/{experiment_id}.json"
+    async with get_managed_export_ingester(settings) as export_ingester:
+        await export_ingester.ingest_archive(
+            remote, ArchiveParams(experiment_id=experiment_id)
+        )
+
+
+if __name__ == "__main__":
+    experiment_id = sys.argv[1]
+    asyncio.run(main(experiment_id))

--- a/export-ingester/export_ingester/archive_export.py
+++ b/export-ingester/export_ingester/archive_export.py
@@ -9,14 +9,16 @@ from .ingest import get_managed_export_ingester
 async def main(experiment_id: str):
     settings = Settings()
     remote = f"/scratch-shared/amftrack2024/daily/{experiment_id}.json"
-    sbatch_command = ("sbatch /gpfs/home4/mkerrwinter/orchestrator/orchestrator/bash_scripts/downloader_archive.sh"
-     " /scratch-shared/amftrack2024/test_tape")
+    sbatch_command = (
+        "sbatch /gpfs/home4/mkerrwinter/orchestrator/"
+        "orchestrator/bash_scripts/downloader_archive.sh"
+        " /scratch-shared/amftrack2024/test_tape"
+    )
     async with get_managed_export_ingester(settings) as export_ingester:
         await export_ingester.ingest_archive(
             remote, ArchiveParams(experiment_id=experiment_id)
         )
         await export_ingester.run_sbatch_command(sbatch_command, remote)
-
 
 
 if __name__ == "__main__":

--- a/export-ingester/export_ingester/ingest.py
+++ b/export-ingester/export_ingester/ingest.py
@@ -3,7 +3,7 @@ from typing import AsyncGenerator
 
 import httpx
 
-from .api_client import APIClient, ExportParams
+from .api_client import APIClient, ArchiveParams, ExportParams
 from .config import Settings
 from .sftp import SSHClient, SSHClientFactory
 
@@ -25,6 +25,16 @@ class ExportIngester:
         await self.ssh_client.pipe_exports(
             remote_path,
             await self.api_client.get_exports(params),
+        )
+
+    async def ingest_archive(
+        self,
+        remote_path: str,
+        params: ArchiveParams,
+    ):
+        await self.ssh_client.pipe_exports_archive(
+            remote_path,
+            await self.api_client.get_archives(params),
         )
 
     async def run_sbatch_command(self, sbatch_command, remote):

--- a/export-ingester/export_ingester/main.py
+++ b/export-ingester/export_ingester/main.py
@@ -11,8 +11,8 @@ async def main():
     settings = Settings()
     remote = f"/scratch-shared/amftrack2024/daily/{date.today()}.json"
     # TODO these two need to become either parameter or environment variables
-    start = get_date_start(date.today())
-    end = start - settings.TIME_RANGE
+    end = get_date_start(date.today())
+    start = end - settings.TIME_RANGE
     async with get_managed_export_ingester(settings) as export_ingester:
         await export_ingester.ingest(remote, ExportParams(start=start, end=end))
         await export_ingester.run_sbatch_command(settings.SBATCH_COMMAND, remote)

--- a/export-ingester/export_ingester/worker.py
+++ b/export-ingester/export_ingester/worker.py
@@ -36,7 +36,7 @@ async def run_ingestion(ctx: dict, *, _date: date | None = None):
 
 class WorkerSettings:
     cron_jobs = [
-        cron(run_ingestion, hour={11}, minute={17}),
+        cron(run_ingestion, hour={11}, minute={21}),
     ]
 
     timezone = ZoneInfo("Europe/Amsterdam")

--- a/export-ingester/export_ingester/worker.py
+++ b/export-ingester/export_ingester/worker.py
@@ -36,7 +36,7 @@ async def run_ingestion(ctx: dict, *, _date: date | None = None):
 
 class WorkerSettings:
     cron_jobs = [
-        cron(run_ingestion, hour={11}),
+        cron(run_ingestion, hour={11},minute = {15}),
     ]
 
     timezone = ZoneInfo("Europe/Amsterdam")

--- a/export-ingester/export_ingester/worker.py
+++ b/export-ingester/export_ingester/worker.py
@@ -27,8 +27,8 @@ async def run_ingestion(ctx: dict, *, _date: date | None = None):
     settings: Settings = ctx["settings"]
     remote = f"/scratch-shared/amftrack2024/daily/{date.today()}.json"
     # TODO these two need to become either parameter or environment variables
-    start = get_date_start(date.today())
-    end = start - settings.TIME_RANGE
+    end = get_date_start(date.today())
+    start = end - settings.TIME_RANGE
     async with get_managed_export_ingester(settings) as ingester:
         await ingester.ingest(remote, ExportParams(start=start, end=end))
         await ingester.run_sbatch_command(settings.SBATCH_COMMAND, remote)

--- a/export-ingester/export_ingester/worker.py
+++ b/export-ingester/export_ingester/worker.py
@@ -36,7 +36,7 @@ async def run_ingestion(ctx: dict, *, _date: date | None = None):
 
 class WorkerSettings:
     cron_jobs = [
-        cron(run_ingestion, hour={11},minute = {17}),
+        cron(run_ingestion, hour={11}, minute={17}),
     ]
 
     timezone = ZoneInfo("Europe/Amsterdam")

--- a/export-ingester/export_ingester/worker.py
+++ b/export-ingester/export_ingester/worker.py
@@ -36,7 +36,7 @@ async def run_ingestion(ctx: dict, *, _date: date | None = None):
 
 class WorkerSettings:
     cron_jobs = [
-        cron(run_ingestion, hour={11},minute = {15}),
+        cron(run_ingestion, hour={11},minute = {17}),
     ]
 
     timezone = ZoneInfo("Europe/Amsterdam")


### PR DESCRIPTION
## Description

- Created a `archive_export.py` script to export archive json from API to remote server. This is still experimental but was necessary to start trying out implementation of archive retrieval on server side.
- fixed job executing every minute at 11 (due to cron unspecification of minute)
- fixed inverted start and end


## Implementation

- Added `ingest_archive` method to `ExportIngester` class
- Added `pipe_exports_archive` method to `SSHClient` class (might be redundant)
- modified `limit` in `Params` to avoid the upper limit imposed
- added `minute` to `run_ingestion` cron setting
